### PR TITLE
Fix SSH X11 forwarding and tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ I've found that out of the box, 1Password SSH Agent and CLI don't provide the be
 
 ### Use Case
 
-Assume I have 1Password installed on all of my macOS and Linux desktop systems, and I SSH from a Linux desktop into a macOS system. SSH agent forwarding will mostly take care of using 1Password SSH Agent over SSH with a [carefully configured tmux](https://blog.testdouble.com/posts/2016-11-18-reconciling-tmux-and-ssh-agent-forwarding/).
+Assume I have 1Password installed on all of my macOS and Linux desktop systems, and I SSH from a Linux desktop into a macOS system. SSH agent forwarding will mostly take care of using 1Password SSH Agent over SSH with a [carefully configured tmux](https://babushk.in/posts/renew-environment-tmux.html).
 
 However, trying to use scripts that rely on 1Password CLI while logged in remotely over SSH will not work very well because the [1Password CLI communicates with the 1Password app](https://developer.1password.com/docs/cli/app-integration-security/#how-does-1password-cli-communicate-with-the-1password-app) running on the same host. In this example, the authorization prompt for CLI access goes to a the macOS desktop (i.e., the system I'm logged in remotely to) instead of the Linux desktop where I'm logged in locally and have access to the 1Password desktop app.
 

--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -10,12 +10,8 @@ bind v split-window -h
 set -g mouse on
 
 # Regarding update-environment:
-#  Remove SSH_AUTH_SOCK to disable tmux automatically resetting the variable
-#  https://blog.testdouble.com/posts/2016-11-18-reconciling-tmux-and-ssh-agent-forwarding/
+#  Update all the typical SSH related variables plus the X Display.
 #
 #  Add LC_DESKTOP_HOST to support 1Password over SSH
 #  https://github.com/mmercurio/dotfiles
-set -g update-environment "SSH_ASKPASS SSH_AGENT_PID SSH_CONNECTION LC_DESKTOP_HOST"
-
-# Use a symlink to look up SSH authentication
-setenv -g SSH_AUTH_SOCK $HOME/.ssh/agent.sock
+set-option -g update-environment "SSH_ASKPASS SSH_AUTH_SOCK SSH_AGENT_PID SSH_CONNECTION DISPLAY LC_DESKTOP_HOST"

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -158,6 +158,23 @@ sshid () {
 	sshpw-id $* && ssh $*
 }
 
+# When in tmux refresh SSH_AUTH_SOCK and DISPLAY
+# https://babushk.in/posts/renew-environment-tmux.html
+if [[ -n "$TMUX" ]]; then
+    function refresh {
+        eval $(tmux showenv -s SSH_AUTH_SOCK)
+        eval $(tmux showenv -s DISPLAY)
+    }
+else
+    function refresh { }
+fi
+
+# zsh executes preexec before each command
+function preexec {
+    # Refresh environment if inside tmux
+    refresh
+}
+
 # Load 1Password SSH environment
 [[ ! -f ~/.ssh/env_1password ]] || source ~/.ssh/env_1password
 

--- a/home/private_dot_ssh/private_executable_rc
+++ b/home/private_dot_ssh/private_executable_rc
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# https://blog.testdouble.com/posts/2016-11-18-reconciling-tmux-and-ssh-agent-forwarding/
-
-# Fix SSH auth socket location so agent forwarding works with tmux
-if test "$SSH_AUTH_SOCK" ; then
-    ln -sf $SSH_AUTH_SOCK ~/.ssh/agent.sock
-fi


### PR DESCRIPTION
This update fixes an issue that prevented SSH X11 forwarding from working (at all), and also ensure it works properly from tmux.

Previously I was using `~/.ssh/rc` to execute commands when logging in via SSH, but this was a mistake. Care must be taken if choosing to use `~/.ssh/rc` file because it affects how sshd handles xauth during X11 forwarding.

From [sshd(8)](https://linux.die.net/man/8/sshd) man page:

> If the file ~/.ssh/rc exists, [sh](https://linux.die.net/man/1/sh)(1) runs it after reading the environment files but before starting the user's shell or command. It must not produce any output on stdout; stderr must be used instead. If X11 forwarding is in use, it will receive the "proto cookie" pair in its standard input (and DISPLAY in its environment). _**The script must call [xauth](https://linux.die.net/man/1/xauth)(1) because sshd will not run xauth automatically to add X11 cookies.**_

Because I was using `~/.ssh/rc` file and it most definitely was not calling xauth, it meant X11 forwarding was broken. Attempting to launch graphical applications over the SSH session resulted in the following error: 

```
X11 connection rejected because of wrong authentication.
Error: Can't open display: localhost:11.0
```

Additionally, I didn't like fixing the location of the SSH agent socket which has the disadvantage of not allowing multiple SSH sessions with agent forwarding from different agents/hosts. This was a shortcut to get around needing to update the `SSH_AUTH_SOCK` variable for tmux. The new method automatically updates both `SSH_AUTH_SOCK` and `DISPLAY` so that both SSH Agent forwarding and X11 forwarding work properly from tmux. Credit goes to [Igor Babuschkin](https://babushk.in/posts/renew-environment-tmux.html). 

