### PR TITLE
tmux consistent across versions

### DIFF
--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -28,18 +28,11 @@ bind -T copy-mode-vi y send -X copy-selection-and-cancel
 bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-selection-and-cancel
 bind P paste-buffer
 # Version-specific config. 😢
-# tmux versions >= 3.3 will need:
-#   bind -T copy-mode-vi Y send -X copy-line-and-cancel
-# tmux versions < 3.3, will need:
-#   bind -T copy-mode-vi Y send -X copy-line
-#
-#display-message -p "version: #{version}"
 %if #{>=:#{version},3.3}
    bind -T copy-mode-vi Y send -X copy-line-and-cancel
-   #display-message -p "version 3.3 and above: copy-line-and-cancel for vim Y"
 %else
+   # needed for version older than 3.3
    bind -T copy-mode-vi Y send -X copy-line
-   #display-message -p "version less than 3.3: copy-line for vim Y"
 %endif
 
 # Fast pane switching using Meta (Alt) vi keys:

--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -22,16 +22,28 @@ bind C-a send-prefix
 bind h split-window -v
 bind v split-window -h
 
-# Behave like vim for visual copy/yank and paste
+# Behave like vim for visual copy/yank and paste/put
 bind -T copy-mode-vi v send -X begin-selection
 bind -T copy-mode-vi y send -X copy-selection-and-cancel
-bind -T copy-mode-vi Y send -X copy-line # why not copy-line-and-cancel???
 bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-selection-and-cancel
 bind P paste-buffer
-
-# Fast pane switching using Meta (Alt) vi keys
-#   https://hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/
+# Version-specific config. 😢
+# tmux versions >= 3.3 will need:
+#   bind -T copy-mode-vi Y send -X copy-line-and-cancel
+# tmux versions < 3.3, will need:
+#   bind -T copy-mode-vi Y send -X copy-line
 #
+#display-message -p "version: #{version}"
+%if #{>=:#{version},3.3}
+   bind -T copy-mode-vi Y send -X copy-line-and-cancel
+   #display-message -p "version 3.3 and above: copy-line-and-cancel for vim Y"
+%else
+   bind -T copy-mode-vi Y send -X copy-line
+   #display-message -p "version less than 3.3: copy-line for vim Y"
+%endif
+
+# Fast pane switching using Meta (Alt) vi keys:
+#   https://hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/
 # To get this to work properly on the Mac under iTerm2, need to
 # configure iTerm, under Profile, Keys to send "+Esc" for Left option (⌥) key:
 #   https://superuser.com/a/650900/384322
@@ -42,8 +54,7 @@ bind -n M-j select-pane -D
 
 
 # Regarding update-environment:
-#  Update all the typical SSH related variables plus the X Display.
-#
-#  Add LC_DESKTOP_HOST to support 1Password over SSH
-#  https://github.com/mmercurio/dotfiles
+# - Update all the typical SSH related variables plus the X Display.
+# - Add LC_DESKTOP_HOST to support 1Password over SSH
+#   https://github.com/mmercurio/dotfiles
 set -g update-environment "SSH_ASKPASS SSH_AUTH_SOCK SSH_AGENT_PID SSH_CONNECTION DISPLAY LC_DESKTOP_HOST"

--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -1,22 +1,49 @@
-set -g default-terminal "xterm-256color"
-set -g prefix C-a
-set -g mouse on
-setw -g mode-keys vi
+# Depending on tmux/termcap version and distribution TERM variable
+# for shells running within tmux may default to screen (e.g. Ubuntu 22.04).
+# Set explicitly to tmux for full terminal capabilites on modern systems.
+set -g default-terminal "tmux-256color"
 
-#unbind C-b
-bind-key C-a send-prefix
+set -g mouse on
+set -g set-clipboard on
+
+# These are normaly not needed because it's the default when EDITOR is set to vi
+set -g mode-keys vi
+set -g status-keys vi
+
+# window and pane index start at 1
+set -g base-index 1
+set -g pane-base-index 1
+
+# using C-a as prefix
+set -g prefix C-a
+unbind C-b
+bind C-a send-prefix
 
 bind h split-window -v
 bind v split-window -h
 
+# Behave like vim for visual copy/yank and paste
 bind -T copy-mode-vi v send -X begin-selection
-bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
+bind -T copy-mode-vi y send -X copy-selection-and-cancel
+bind -T copy-mode-vi Y send -X copy-line # why not copy-line-and-cancel???
+bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-selection-and-cancel
 bind P paste-buffer
-bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
+
+# Fast pane switching using Meta (Alt) vi keys
+#   https://hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/
+#
+# To get this to work properly on the Mac under iTerm2, need to
+# configure iTerm, under Profile, Keys to send "+Esc" for Left option (⌥) key:
+#   https://superuser.com/a/650900/384322
+bind -n M-h select-pane -L
+bind -n M-l select-pane -R
+bind -n M-k select-pane -U
+bind -n M-j select-pane -D
+
 
 # Regarding update-environment:
 #  Update all the typical SSH related variables plus the X Display.
 #
 #  Add LC_DESKTOP_HOST to support 1Password over SSH
 #  https://github.com/mmercurio/dotfiles
-set-option -g update-environment "SSH_ASKPASS SSH_AUTH_SOCK SSH_AGENT_PID SSH_CONNECTION DISPLAY LC_DESKTOP_HOST"
+set -g update-environment "SSH_ASKPASS SSH_AUTH_SOCK SSH_AGENT_PID SSH_CONNECTION DISPLAY LC_DESKTOP_HOST"


### PR DESCRIPTION
Ensure consistent functionality on multiple versions of tmux (3.2a through 3.5a) on both Linux and macOS:

- On Linux ensure TERM is correct and working.
- Ensure copy/paste works with system clipboard
- Make vi mode work more like vim visual mode for copy/yank and paste/put
- Fast pane switching with Meta (Alt) vi keys

Tested successfully on:

- tmux 3.2a, Ubuntu 22.04
- tmux 3.3a, Debian GNU/Linux 12 (bookworm)
- tmux 3.5a, macOS Sequoia 16.5

Due to a backward incompatible change introduced in tmux [version 3.3](https://github.com/tmux/tmux/blob/master/CHANGES#L342):

> * Change copy-line and copy-end-of-line not to cancel and add -and-cancel
  variants, like the other copy commands.

version-specific config (prior to version 3.3 versus after) is needed to get the vi-style copy/yank commands to work properly:

```tmux
%if #{>=:#{version},3.3}
   bind -T copy-mode-vi Y send -X copy-line-and-cancel
%else
   bind -T copy-mode-vi Y send -X copy-line
%endif
```
