### PR TITLE
zsh history fixes

### DIFF
--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -70,10 +70,41 @@ setopt hist_ignore_dups       # ignore duplicated commands history list
 setopt hist_ignore_space      # ignore commands that start with space
 setopt hist_verify            # show command with history expansion to user before running it
 
-# Do NOT share history beween shells -- I hate this; extremely annoying
-# Do NOT share history beween shells. NEVER. EVER!
-setopt no_share_history
-unsetopt share_history
+setopt hist_reduce_blanks     # Remove superfluous blanks from each command
+
+##
+# experimenting with history options (see man zshoptions)
+# This helps with allowing history to be shared between shells
+# and still allow sane up-arrow to recall most recent command.
+#
+# I *HATE* when up-arrow (or !!) recalls a command from
+# another shell's history. I'm expecting the most recent
+# command to be from the local shell's history.
+#
+# **** DOES NOT WORK!
+# https://zsh.sourceforge.io/Doc/Release/Options.html#History
+# https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html
+#
+# https://superuser.com/a/691603
+setopt share_history
+bindkey "${key[Up]}" up-line-or-local-history
+bindkey "${key[Down]}" down-line-or-local-history
+
+up-line-or-local-history() {
+    zle set-local-history 1
+    zle up-line-or-history
+    zle set-local-history 0
+}
+zle -N up-line-or-local-history
+
+down-line-or-local-history() {
+    zle set-local-history 1
+    zle down-line-or-history
+    zle set-local-history 0
+}
+zle -N down-line-or-local-history
+
+##
 
 # Would you like to use another custom folder than $ZSH/custom?
 # ZSH_CUSTOM=/path/to/new-custom-folder
@@ -226,6 +257,3 @@ typeset -g POWERLEVEL9K_INSTANT_PROMPT=quiet
 export SDKMAN_DIR="$HOME/.sdkman"
 [[ ! -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] || source "$HOME/.sdkman/bin/sdkman-init.sh"
 
-# Do NOT share history beween shells. NEVER. EVER!
-setopt no_share_history
-unsetopt share_history


### PR DESCRIPTION
Experimenting with better behavior for zsh history when recalling or cycling through previous commands using up/down arrows. 

Specifically, I expect that a single up arrow will recall the most recently executed command in the current shell. I still want shared history so that _searching_ for previous commands will search the command history from all shell. However, up arrow should always recall the last command from the current shell.