### PR TITLE
macOS Browserino

### DIFF
--- a/home/.chezmoiscripts/darwin/run_onchange_before_50-install-packages-darwin.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_onchange_before_50-install-packages-darwin.sh.tmpl
@@ -54,7 +54,6 @@ eval "$(/usr/local/bin/brew shellenv)"
      "flux"
      "finicky"
      "brave-browser"
-     "browserosaurus"
      "fantastical"
      "cardhop"
      "google-chrome"
@@ -79,3 +78,5 @@ cask "{{ . }}"
 {{   end }}
 {{ end -}}
 EOF
+
+brew install --cask AlexStrNik/Browserino/browserino

--- a/home/dot_finicky.js
+++ b/home/dot_finicky.js
@@ -5,7 +5,7 @@ const GH = {
 }
 
 export default {
-  defaultBrowser: "Browserosaurus", // "Safari"
+  defaultBrowser: "Browserino", // "Safari"
   handlers: [
     {
       match: [


### PR DESCRIPTION
Now that [Browserosaurus is being retired](https://wstone.uk/blog/the-retirement-of-browserosaurus/), replacing with [Browserino](https://github.com/AlexStrNik/Browserino).
