### PR TITLE
2ip - error handling and performance improvements

### DIFF
--- a/home/bin/executable_2ip
+++ b/home/bin/executable_2ip
@@ -7,23 +7,31 @@
 #    ip-10-173-42-1
 #    ip-10-173-42-1.optional.domain
 #
-#  Output the IP address or original hostname if the IP address
-#  cannot be extracted. Hostnames are specified on the command
-#  line or read from stdin.
+#  Output the IP address, or the original hostname if the IP address
+#  cannot be extracted.
+#
+#  Hostnames are specified on the command line or read from stdin.
 
-host_pattern='^ip-[0-9]{1,3}-[0-9]{1,3}-[0-9]{1,3}-[0-9]{1,3}'
+host_pattern='^ip-([0-9]+)-([0-9]+)-([0-9]+)-([0-9]+)'
 
-# hosts2ip hostname [hostname ...]
-#   For each hostname, echo the IP address if the hostname is
-#   an EC2-style hostname such as ip-10-172-42-1.optional.domain.
-#   Otherwise just echo the original hostname.
+function host2ip() {
+    local host=$1
+    if [[ "$host" =~ $host_pattern ]]; then
+        for octet in "${BASH_REMATCH[@]:1:4}"; do
+            if [[ octet -gt 255 ]]; then
+                echo "$host"
+                return
+            fi
+        done
+        echo "$host" | sed -e 's/^ip-//' -e 's/\..*$//' -e 's/-/./g'
+    else
+        echo "$host"
+    fi
+}
+
 function hosts2ip() {
     for host in "$@"; do
-        if [[ "$host" =~ $host_pattern ]]; then
-            echo "$host" | sed -e 's/^ip-//' -e 's/\..*$//' -e 's/-/./g'
-        else
-            echo "$host"
-        fi
+        host2ip "$host"
     done
 }
 

--- a/home/bin/executable_2ip
+++ b/home/bin/executable_2ip
@@ -23,7 +23,9 @@ function host2ip() {
                 return
             fi
         done
-        echo "$host" | sed -e 's/^ip-//' -e 's/\..*$//' -e 's/-/./g'
+        host=${host/#ip-/}    # remove "ip-" prefix
+        host=${host/%\.*/}    # remove optional domain suffix
+        echo "${host//-/.}"   # transpose "-" to "."
     else
         echo "$host"
     fi

--- a/home/bin/executable_2ip
+++ b/home/bin/executable_2ip
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Usage: 2ip [hostname ...]
+# Usage: 2ip [host ...]
 #
 #  Extract IP addresses from AWS EC2-style hostnames such as:
 #
@@ -14,6 +14,8 @@
 
 host_pattern='^ip-([0-9]{1,3})-([0-9]{1,3})-([0-9]{1,3})-([0-9]{1,3})($|\.)'
 
+# Attempt to extract IP address from single hostname as the first arg.
+# IP address or original hostname is sent to stdout.
 function host2ip() {
     local host=$1
     if [[ "$host" =~ $host_pattern ]]; then

--- a/home/bin/executable_2ip
+++ b/home/bin/executable_2ip
@@ -12,20 +12,22 @@
 #
 #  Hostnames are specified on the command line or read from stdin.
 
-host_pattern='^ip-([0-9]+)-([0-9]+)-([0-9]+)-([0-9]+)'
+host_pattern='^ip-([0-9]{1,3})-([0-9]{1,3})-([0-9]{1,3})-([0-9]{1,3})($|\.)'
 
 function host2ip() {
     local host=$1
     if [[ "$host" =~ $host_pattern ]]; then
+        local -a octets
         for octet in "${BASH_REMATCH[@]:1:4}"; do
+            octet=$((10#$octet))  # force base 10 to remove leading zeros if any
             if [[ octet -gt 255 ]]; then
                 echo "$host"
                 return
             fi
+            octets+=("$octet")
         done
-        host=${host/#ip-/}    # remove "ip-" prefix
-        host=${host/%\.*/}    # remove optional domain suffix
-        echo "${host//-/.}"   # transpose "-" to "."
+        local IFS=.
+        echo "${octets[*]}" # each octet separated by "." (IFS)
     else
         echo "$host"
     fi


### PR DESCRIPTION
Handle and detect patterns where valid IP addresses cannot be extracted and remove the dependency on `sed`.

Example of hostname patterns where IP addresses are extracted:

```shell
2ip ip-10-171-32-99 ip-192-168-32-0.optional.domain ip-001-002-003-004.okay
10.171.32.99
192.168.32.0
1.2.3.4
```

Examples of hostname patterns that fail to meet the criteria: 

```shell
2ip ip-409-19-2311.ssn ip-10.171.32.99 ip-192-168-32-0-not.ok
ip-409-19-2311.ssn
ip-10.171.32.99
ip-192-168-32-0-not.ok
```